### PR TITLE
Add basic warehouse receiving system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Activebox
 Here you can see [demo](https://takhirzorba.github.io/activebox/)
+## Warehouse Receiving System
+Open receive.html to manage incoming goods.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,113 @@
+function loadItems() {
+  const data = localStorage.getItem('items');
+  return data ? JSON.parse(data) : [];
+}
+
+function saveItems(items) {
+  localStorage.setItem('items', JSON.stringify(items));
+}
+
+function renderZone(list, elementId, renderFn) {
+  const container = document.getElementById(elementId);
+  if (!container) return;
+  container.innerHTML = '';
+  list.forEach(item => container.appendChild(renderFn(item)));
+}
+
+function showGreenItem(item) {
+  const li = document.createElement('li');
+  li.textContent = `${item.track} - ${item.name} (${item.receivedQty})`;
+  return li;
+}
+
+function showYellowItem(item) {
+  const li = document.createElement('li');
+  li.textContent = `${item.track} - ${item.name} (ожидалось ${item.expectedQty}, принято ${item.receivedQty})`;
+  return li;
+}
+
+function showGreyItem(item) {
+  const li = document.createElement('li');
+  const span = document.createElement('span');
+  span.textContent = `${item.track} - ${item.name} (ожидается ${item.expectedQty})`;
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.value = item.expectedQty;
+  const btn = document.createElement('button');
+  btn.textContent = 'Обновить';
+  btn.onclick = () => {
+    const items = loadItems();
+    const target = items.find(i => i.track === item.track);
+    target.expectedQty = Number(input.value);
+    saveItems(items);
+    renderLists();
+  };
+  li.appendChild(span);
+  li.appendChild(input);
+  li.appendChild(btn);
+  return li;
+}
+
+function renderLists() {
+  const items = loadItems();
+  renderZone(items.filter(i => i.status === 'green'), 'green-list', showGreenItem);
+  renderZone(items.filter(i => i.status === 'yellow'), 'yellow-list', showYellowItem);
+  renderZone(items.filter(i => !i.status || i.status === 'grey'), 'grey-list', showGreyItem);
+}
+
+function searchItem() {
+  const track = document.getElementById('track-input').value.trim();
+  const items = loadItems();
+  const item = items.find(i => i.track === track);
+  if (!item) {
+    alert('Товар не найден');
+    return;
+  }
+  document.getElementById('product-info').style.display = 'block';
+  document.getElementById('product-name').textContent = item.name;
+  document.getElementById('expected').textContent = item.expectedQty;
+  document.getElementById('submit-btn').onclick = () => submitQty(item);
+}
+
+function submitQty(item) {
+  const qty = Number(document.getElementById('received-input').value);
+  const items = loadItems();
+  const target = items.find(i => i.track === item.track);
+  target.receivedQty = qty;
+  if (qty === target.expectedQty) {
+    target.status = 'green';
+    document.getElementById('barcode').textContent = `Штрихкод: ${target.track}`;
+  } else {
+    target.status = 'yellow';
+  }
+  saveItems(items);
+  renderLists();
+  document.getElementById('product-info').style.display = 'none';
+  document.getElementById('track-input').value = '';
+  document.getElementById('received-input').value = '';
+}
+
+document.getElementById('search-btn').addEventListener('click', searchItem);
+
+document.getElementById('import-btn').onclick = () => {
+  try {
+    const data = JSON.parse(document.getElementById('import-data').value);
+    const items = loadItems();
+    data.forEach(d => items.push({ ...d, status: 'grey' }));
+    saveItems(items);
+    renderLists();
+  } catch (e) {
+    alert('Неверный формат');
+  }
+};
+
+document.getElementById('export-btn').onclick = () => {
+  const items = loadItems().filter(i => i.status === 'green');
+  const dataStr = 'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(items));
+  const dl = document.createElement('a');
+  dl.setAttribute('href', dataStr);
+  dl.setAttribute('download', 'accepted.json');
+  dl.click();
+};
+
+renderLists();

--- a/receive.html
+++ b/receive.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <title>Система приемки</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Система приемки</h1>
+
+  <section id="scan-section">
+    <label>Сканируйте трек: <input type="text" id="track-input"></label>
+    <button id="search-btn">Найти</button>
+  </section>
+
+  <div id="product-info" style="display:none;">
+    <p id="product-name"></p>
+    <p>Ожидаемое количество: <span id="expected"></span></p>
+    <label>Принятое количество: <input type="number" id="received-input"></label>
+    <button id="submit-btn">Подтвердить</button>
+    <div id="barcode"></div>
+  </div>
+
+  <h2>Зеленая зона</h2>
+  <ul id="green-list"></ul>
+
+  <h2>Желтая зона</h2>
+  <ul id="yellow-list"></ul>
+
+  <hr>
+
+  <section id="admin-panel">
+    <h2>Админ панель</h2>
+    <h3>Серая зона</h3>
+    <ul id="grey-list"></ul>
+
+    <h3>Импорт базы товаров</h3>
+    <textarea id="import-data" placeholder='[{"track":"123","name":"Товар","expectedQty":5}]'></textarea>
+    <button id="import-btn">Импорт</button>
+
+    <h3>Экспорт принятых товаров</h3>
+    <button id="export-btn">Экспорт</button>
+  </section>
+
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add receive.html with UI for scanning tracks, accepting quantities, and viewing green/yellow zones
- introduce app.js managing zones, import/export, and admin adjustments
- document warehouse system usage in README

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c12ff0b483258568523057c944cb